### PR TITLE
Make ok_url more useful

### DIFF
--- a/Network/URL.hs
+++ b/Network/URL.hs
@@ -238,9 +238,9 @@ ok_path :: Char -> Bool
 ok_path c   = ok_param c || c `elem` "/=&"
 
 -- XXX: others? check RFC
--- | Characters that may appear in the textual representation of a URL
+-- | Characters that do not need to be encoded in URL
 ok_url :: Char -> Bool
-ok_url c = isDigit c || isAlphaASCII c || c `elem` ".-;:@$_!*'(),/=&?~%+"
+ok_url c = isDigit c || isAlphaASCII c || c `elem` ".-;:@$_!*'(),/=&?~+"
 
 -- Misc
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Not sure how you are supposed to use encString, but it's a lot easier to use, if ok_url checks for the the characters that need to be encoded, not the ones that are allowed. That is '%' needs to be encoded, but is allowed in the encoded string as it is the result of encoding process.
