### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/url.cabal
+++ b/url.cabal
@@ -9,7 +9,7 @@ license:      BSD3
 license-file: LICENSE
 homepage:     http://www.haskell.org/haskellwiki/Url
 
-cabal-version: >= 1.6
+cabal-version: >= 1.8
 build-type:    Simple
 
 library


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: url.cabal:20:28: version operators used. To use version operators the                                                           
package needs to specify at least 'cabal-version: >= 1.8'.  
```